### PR TITLE
增加对Katex的支持

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,3 +51,9 @@ valine:
   avatar: 'mp'
   pageSize: '10'
   placeholder: '请输入...' 
+
+# Katex Support
+katex:
+  enable: false # true
+  allpost:
+  copy_tex:

--- a/layout/_partial/post/katex.ejs
+++ b/layout/_partial/post/katex.ejs
@@ -1,0 +1,11 @@
+<% if ( theme.katex.enable ) { %>
+    <% if( theme.katex.allpost || page.math ) { %>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
+        <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/katex/dist/contrib/auto-render.js"></script>
+        <% if ( theme.katex.copy_tex ) { %>
+            <script src="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/copy-tex.min.js"></script>
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/copy-tex.css">
+        <% } %>
+    <% } %>
+<% } %>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -8,5 +8,6 @@
   <%- partial('_partial/sidebar',null, {cache: !config.relative_link}) %>
 </aside>
 <%- partial('_partial/after-footer') %>
+<%- partial('_partial/post/katex') %>
 </body>
 </html>


### PR DESCRIPTION
❗需要更换渲染器为hexo-renderer-markdown-it-plus
allpost为true则每篇文章都渲染Katex，否则只在front-matter处写有math: true的文章中渲染
copy_tex为true则在网页上选择公式可以复制得到公式的Katex源码