### PR TITLE
feat: 新增复制代码块按钮

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ ocean:
 excerpt_link: Read More...
 
 # MIIT ICP/IP/DOMAIN
-beian: 
+beian:
   enable: true
   number: 京ICP备17054916号-2
   url: https://beian.miit.gov.cn/
@@ -35,6 +35,9 @@ toc: true
 
 # fancybox
 fancybox: true
+
+# 是否显示复制按钮
+show_copy_btn: true
 
 # Gitalk
 gitalk:
@@ -49,10 +52,10 @@ gitalk:
 valine:
   enable: false # true
   el: 'vcomments'
-  appId: 
-  appKey: 
+  appId:
+  appKey:
   notify: false
   verify: true
   avatar: 'mp'
   pageSize: '10'
-  placeholder: '请输入...' 
+  placeholder: '请输入...'

--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -5,6 +5,9 @@
 <% if (theme.fancybox){ %>
 <%- js('fancybox/jquery.fancybox.min') %>
 <% } %>
+<% if (theme.show_copy_btn){ %>
+<%- js('/js/copybtn') %>
+<% } %>
 
 <% if (theme.toc && is_post()){ %>
 <%- js('/js/tocbot.min') %>

--- a/source/css/_partial/layou.styl
+++ b/source/css/_partial/layou.styl
@@ -14,6 +14,14 @@
   margin-right 0
   &.on
     transform translateX(- aside-width)
+  .copy-btn
+    position absolute
+    font-size 12px
+    color hsla(0,0%,54.9%,.8)
+    transition color .1s
+    cursor pointer
+  .copy-btn:hover
+    color hsla(0,0%,54.9%,1)
 
 .sidebar
   position fixed

--- a/source/js/copybtn.js
+++ b/source/js/copybtn.js
@@ -1,0 +1,127 @@
+!(function ($, window) {
+  var TEXT = {
+    default: '复制',
+    success: '复制成功',
+    fail: '复制失败',
+  };
+
+  /**
+   * 复制文本
+   * @param {HTMLElement} selectNode 需要复制的元素
+   * @param {*} copyBtnInstance 复制按钮的实例
+   */
+  function copyText(selectNode, copyBtnInstance) {
+    try {
+      var range = document.createRange();
+      range.selectNode(selectNode);
+      window.getSelection().removeAllRanges();
+      window.getSelection().addRange(range);
+      document.execCommand('copy');
+      window.getSelection().removeAllRanges();
+      copyBtnInstance.changeStatus(1);
+    } catch (e) {
+      copyBtnInstance.changeStatus(0);
+    }
+  }
+
+  /**
+   * 生成复制按钮
+   * @param {number} top 按钮距离页面顶部的值
+   * @param {number} right
+   */
+  function GenCopyBtn(top, right) {
+    this.el = document.createElement('span');
+    this.el.innerText = TEXT.default;
+    this.el.setAttribute('class', 'copy-btn');
+    this.el.style.top = top + 'px';
+    this.el.style.right = right + 'px';
+  }
+
+  GenCopyBtn.prototype = {
+    getEl: function () {
+      return this.el;
+    },
+    changeStatus: function (status) {
+      this.el.innerText = TEXT.success;
+      if (!status) {
+        this.el.innerText = TEXT.fail;
+        this.el.style.color = '#dd524d';
+      }
+      this.reset(800);
+    },
+    reset: function (delay) {
+      var _this = this;
+      setTimeout(function () {
+        _this.el.innerText = TEXT.default;
+        _this.el.style.color = '';
+      }, delay)
+    },
+  }
+
+  var MARGIN = 10; // 距离代码块的边距
+  var highlights = $('.highlight');
+
+  // 没有该元素就不生成按钮
+  if (!highlights || !highlights.length) {
+    return false;
+  }
+
+  var nodeFragment = document.createDocumentFragment();
+  var mainSelector = '.content';
+
+  /**
+   * 获取按钮的 top 值
+   * @param {HTMLElement} highlightEl 
+   */
+  function getCopyBtnPosY(highlightEl) {
+    var top = $(highlightEl).offset().top;
+    return top;
+  }
+
+    /**
+   * 获取按钮的 right 值
+   * @param {HTMLElement} highlightEl 
+   */
+  function getCopyBtnPosX(highlightEl) {
+    var right = $(mainSelector).width() - highlightEl.outerWidth(true) - highlightEl.offset().left;
+    return right;
+  }
+
+  // 动态添加复制按钮
+  highlights.each(function () {
+    var highlightEl = $(this);
+    var offsetTop = getCopyBtnPosY(highlightEl) + MARGIN;
+    var offsetRight = getCopyBtnPosX(highlightEl) + MARGIN;
+
+    var codeEl = highlightEl.find('.code pre')[0];
+
+    var copyBtnInstance = new GenCopyBtn(offsetTop, offsetRight);
+    var copyBtnEl = copyBtnInstance.getEl();
+    copyBtnEl.addEventListener(
+      'click',
+      copyText.bind(this, codeEl, copyBtnInstance)
+    )
+
+    nodeFragment.appendChild(copyBtnEl);
+  })
+
+  $(mainSelector).append(nodeFragment);
+
+  function autoSetPos() {
+    var copyBtn = $('.copy-btn');
+    if(!copyBtn.length) return;
+
+    copyBtn.each(function(index) {
+      var highlightEl = $(highlights[index]);
+      var offsetTop = getCopyBtnPosY(highlightEl) + MARGIN;
+      var offsetRight = getCopyBtnPosX(highlightEl) + MARGIN;
+      $(this).css({
+        top: offsetTop,
+        right: offsetRight
+      });
+    })
+  }
+  
+  window.addEventListener('resize', autoSetPos);
+  
+})(jQuery, window)


### PR DESCRIPTION
## 唠唠嗑

我是一名前端，在 hexo 主题里一眼就相中了这个高端大气上档次的主题

平时喜欢随便记记写写，奈何主题没有复制代码块的功能，这让我和读者有点难受

于是就有了这个 pr

## 说明

此次改动，在代码块部分新增了一个复制的功能，具体效果可以移步我的博客：[小鑫の随笔 - xiaoxina.cc](https://xiaoxina.cc/)

### 用法

在 ocean 主题文件夹里的 _config.yml 文件里新增配置开启：

```yml
# 是否显示复制按钮
show_copy_btn: true
```

示例图：
![复制按钮示例图](https://xiaoxina.cc/assets/images/copy_btn_demo.png)