### PR TITLE
feat: 添加Waline评论区

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,3 +59,8 @@ valine:
   avatar: 'mp'
   pageSize: '10'
   placeholder: '请输入...'
+
+# Waline
+waline:
+  enable: false  # true
+  serverURL: # Waline ServerURL | READ MORE:https://waline.netlify.app/ 

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -49,6 +49,7 @@
   <% if (is_post()) { %>
   <%- partial('post/valine') %>
   <%- partial('post/gitalk') %>
+  <%- partial('post/waline') %>
   <%} %>
 
 </article>

--- a/layout/_partial/post/waline.ejs
+++ b/layout/_partial/post/waline.ejs
@@ -1,0 +1,53 @@
+<% if (theme.waline.enable) { %>
+<br />
+<script src="//cdn.jsdelivr.net/npm/@waline/client"></script>
+<div id="waline"></div>
+<script>
+  const locale = {
+  nick: '昵称',
+  nickError: '昵称不能少于3个字符',
+  mail: '邮箱',
+  mailError: '请填写正确的邮件地址',
+  link: '网址',
+  placeholder: '匿名或注册登录或Github登录或留下自己的邮箱均可留言~~',
+  sofa: '来发评论吧~',
+  submit: '提交',
+  reply: '回复',
+  cancelReply: '取消回复',
+  comment: '评论',
+  more: '加载更多...',
+  preview: '预览',
+  emoji: '表情',
+  uploadImage: '上传图片',
+  seconds: '秒前',
+  minutes: '分钟前',
+  hours: '小时前',
+  days: '天前',
+  now: '刚刚',
+  uploading: '正在上传',
+  login: '登录',
+  logout: '退出',
+  admin: '博主',
+  word: '字',
+  wordHint: '评论字数应在 $0 到 $1 字之间！\n当前字数：$2',
+};
+
+  Waline({
+    el: '#waline',
+    serverURL: '<%- theme.waline.serverURL %>',
+
+    //设置emoji表情来源
+    emoji: [
+      'https://cdn.jsdelivr.net/gh/walinejs/emojis@1.0.0/weibo',
+      'https://cdn.jsdelivr.net/gh/walinejs/emojis@1.0.0/bilibili',
+      'https://cdn.jsdelivr.net/gh/walinejs/emojis@1.0.0/qq',
+      'https://cdn.jsdelivr.net/gh/walinejs/emojis@1.0.0/alus'
+    ],
+    
+    //默认头像
+    avatar: 'mp',
+    locale,
+    path: location.pathname,
+  });
+</script>
+<% } %>


### PR DESCRIPTION
## 缘由
由于Valine存在一些已知的[安全隐患](https://zhuanlan.zhihu.com/p/295264916),认为 应该将Valine改为Waline,但鉴于可能有的小伙伴还在使用Valine,所以只是添加上Waline的功能而不对Valine进行修改
## 使用方法
首先搭建Waline服务器,详见: https://waline.netlify.app/get-started.html
然后在ocean 主题文件夹里的 _config.yml 文件里新增配置开启：
```
waline:
  enable: false  # true
  serverURL: # 这里填上Waline服务器的地址
```
效果见:[甘甘的博客](https://my-blog-eight-dun.vercel.app/)